### PR TITLE
Initialize options array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+/composer.lock
+/vendor

--- a/src/RandomColor.php
+++ b/src/RandomColor.php
@@ -39,6 +39,7 @@ class RandomColor
 
   static public function one($options = array())
   {
+    $options = array_merge(['format' => '', 'hue' => [], 'luminosity' => ''], $options);
     $h = self::_pickHue($options);
     $s = self::_pickSaturation($h, $options);
     $v = self::_pickBrightness($h, $s, $options);


### PR DESCRIPTION
PHP 8 throws warnings when accessing an undefined key in an array. This PR adds default values to the `$options` array to avoid the warnings.

Even though there are error suppression operators (`@`) before accessing those values, custom error handlers still received that error and log/output it.